### PR TITLE
add keyboard shortcut for susi popup

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -7,7 +7,7 @@
        "default_icon" : {
         "16" : "images/icon.png"
        },
-       "default_title" : "susi_ai",
+       "default_title" : "susi_ai (Alt+Shift+S)",
        "default_popup" : "popup.html"
     },
     "background": {
@@ -29,5 +29,13 @@
       "http://*/*",
       "https://*/*",
       "http://ajax.googleapis.com/ajax/libs/jquery/"
-    ]
+    ],
+
+    "commands": {
+      "_execute_browser_action": {
+        "suggested_key": {
+          "default": "Alt+Shift+S"
+        }
+      }
+    }
 }


### PR DESCRIPTION
<!--
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->
<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #105

#### Checklist

- [x ] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia) and my PR follows them.
- [ x] My branch is up-to-date with the Upstream `nextgen` branch.
- [ ] The unit tests pass locally with my changes <!-- use `nosetests tests/unittests` to run all the tests -->
- [ x] I have added tests that prove my fix is effective or that my feature works
- [ x] I have added necessary documentation (if appropriate)
<!-- If an existing function does not have a docstring, please add one -->
- [ ] All the functions created/modified in this PR contain relevant docstrings.

#### Short description of what this resolves:
This is exactly similar to PR [https://github.com/fossasia/susi_firefoxbot/pull/36](url) by nifey who adds this feature in susi_firefoxbot . Same changes are compatible in manifest.json of chromebot.
So should I ask him instead to send the PR ? 
#### Changes proposed in this pull request:

- For quicker access to the popup type (ALT+SHIFT+S)
![2017-10-03 4](https://user-images.githubusercontent.com/20624380/31123485-c336673c-a85d-11e7-95a1-61bee9b49afe.png)

-
-
