### PR TITLE
make chat data persistent

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -26,6 +26,7 @@
   ],
     "content_security_policy": "script-src 'self' https://api.susi.ai; object-src 'self'",
     "permissions":[
+      "storage",
       "http://*/*",
       "https://*/*",
       "http://ajax.googleapis.com/ajax/libs/jquery/"

--- a/src/script.js
+++ b/src/script.js
@@ -13,6 +13,8 @@ var setting = document.getElementById("setting");
 var dark = false;
 var upCount = 0;
 var shouldSpeak = true;
+var storageItems= [];
+var storageArr = [];
 
 function getCurrentTime() {
     var ap="AM";
@@ -50,7 +52,25 @@ function loading(condition=true){
     }
 }
 
+function restoreMessages(storageItems){
+    if(!storageItems){
+        return;
+    }
+    storageItems.map((item) => {
+        loading(true);
+        loading(false);
+        var newDiv =  messages.childNodes[messages.childElementCount];
+        newDiv.setAttribute("class",item.senderClass);
+        newDiv.innerHTML = item.content;
+    });
+}
 
+chrome.storage.sync.get("message",(items) => {
+    if(items){
+     storageItems=items.message;
+     restoreMessages(storageItems);
+ } 
+});  
 
 function speakOutput(msg,speak=false){
     if(speak){
@@ -169,6 +189,23 @@ function composeSusiMessage(response) {
     newDiv.appendChild(document.createElement("br"));
     newDiv.appendChild(currtime);
     messages.appendChild(newDiv);
+    var storageObj = {
+        senderClass: "",
+        content: "" 
+        };
+    var susimessage = newDiv.innerHTML;
+    storageObj.content = susimessage;
+    storageObj.senderClass = "susinewmessage";
+    chrome.storage.sync.get("message",(items) => {
+        if(items.message){
+            storageArr = items.message;
+            console.log("this was true");
+        }
+        storageArr.push(storageObj);
+        chrome.storage.sync.set({"message":storageArr},() => {
+            console.log("saved");
+        });
+    });
     messages.scrollTop = messages.scrollHeight;
 }
 
@@ -242,6 +279,22 @@ function composeMyMessage(text) {
     messages.appendChild(newDiv);
     textarea.value = "";
     messages.scrollTop = messages.scrollHeight;
+    var storageObj = {
+        senderClass: "",
+        content: "" 
+        };
+    var mymessage = newDiv.innerHTML;
+    storageObj.content = mymessage;
+    storageObj.senderClass = "mynewmessage";
+    chrome.storage.sync.get("message",(items) => {
+        if(items.message){
+            storageArr = items.message;
+        }
+        storageArr.push(storageObj);
+        chrome.storage.sync.set({"message":storageArr},() => {
+            console.log("saved");
+        });
+    });
 }
 
 function submitForm() {


### PR DESCRIPTION
Fixes  #97 

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia) and my PR follows them.
- [x] My branch is up-to-date with the Upstream `master` branch.

#### Short description of what this resolves:
Make the chat data persistent so that closing extension does not result in losing the previous chat results. 

#### Changes proposed in this pull request:

- change `manifest.json` to include `storage` permissions
- use `chrome.storage.sync` to store chat data
