### PR TITLE
fix #144 - Add context menu on text selection and right click

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -4,4 +4,25 @@ chrome.browserAction.onClicked.addListener(function (tab) {
         file: 'script.js'
     });
 });
+
+// create a contextMenu
+var askSusi = chrome.contextMenus.create({
+	"title": "Ask SUSI - \"%s\"",
+	"contexts":["selection"],
+	id:"askSusi"
+});
+
+// perform action on clicking a context menu
+chrome.contextMenus.onClicked.addListener(function(info,tab){
+	var menuId = info.menuItemId;
+	var query = info.selectionText;
+	if(menuId==="askSusi"){
+		chrome.storage.local.set({
+			"askSusiQuery":query
+		});
+		chrome.browserAction.setBadgeText({text: "*"});
+	}
+
+});
+
 /* jshint ignore:end */

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -27,6 +27,7 @@
     "content_security_policy": "script-src 'self' https://api.susi.ai; object-src 'self'",
     "permissions":[
       "storage",
+      "contextMenus",
       "http://*/*",
       "https://*/*",
       "http://ajax.googleapis.com/ajax/libs/jquery/"

--- a/src/script.js
+++ b/src/script.js
@@ -64,14 +64,23 @@ function restoreMessages(storageItems){
         newDiv.setAttribute("class",item.senderClass);
         newDiv.innerHTML = item.content;
     });
+    chrome.storage.local.get("askSusiQuery",(items) => {
+        if(items.askSusiQuery){
+            var query = items.askSusiQuery ;
+			textarea.value=query;
+			document.getElementById("but").click();
+			chrome.storage.local.remove("askSusiQuery");
+            chrome.browserAction.setBadgeText({text: ""});
+     }
+    });
 }
 
 chrome.storage.sync.get("message",(items) => {
     if(items){
      storageItems=items.message;
      restoreMessages(storageItems);
- } 
-});  
+ }
+});
 
 function speakOutput(msg,speak=false){
     if(speak){
@@ -100,7 +109,7 @@ function composeReplyAnswer(response,replyData){
     response.reply = replyData;
     if(replyData.startsWith("https")) {
         response.image = true;
-    } 
+    }
     return response;
 }
 
@@ -177,7 +186,7 @@ function composeSusiMessage(response) {
             else if(response.image) {
                 var newImg = composeImage(response.reply);
                 newDiv.appendChild(document.createElement("br"));
-                newDiv.appendChild(newImg);    
+                newDiv.appendChild(newImg);
             }
             else if(response.tableType) {
                     newDiv.appendChild(response.table);
@@ -192,7 +201,7 @@ function composeSusiMessage(response) {
     messages.appendChild(newDiv);
     var storageObj = {
         senderClass: "",
-        content: "" 
+        content: ""
         };
     var susimessage = newDiv.innerHTML;
     storageObj.content = susimessage;
@@ -215,7 +224,7 @@ function composeResponse(action,data) {
         error: false,
         reply: "",
         image: false,
-        tableType: false 
+        tableType: false
     };
     switch(action.type){
         case "answer" : response = composeReplyAnswer(response,action.expression);
@@ -224,7 +233,7 @@ function composeResponse(action,data) {
                         break;
         default :       response.error = true;
                         response.errorText = "No matching action type";
-                        break; 
+                        break;
     }
     return response;
 }
@@ -235,7 +244,7 @@ function getResponse(query) {
         dataType: "jsonp",
         type: "GET",
         url: "https://api.susi.ai/susi/chat.json?timezoneOffset=-300&q=" + query,
-        error: function(xhr,textStatus,errorThrown) {   
+        error: function(xhr,textStatus,errorThrown) {
                 console.log(xhr);
                 console.log(textStatus);
                 console.log(errorThrown);
@@ -282,7 +291,7 @@ function composeMyMessage(text) {
     messages.scrollTop = messages.scrollHeight;
     var storageObj = {
         senderClass: "",
-        content: "" 
+        content: ""
         };
     var mymessage = newDiv.innerHTML;
     storageObj.content = mymessage;
@@ -341,7 +350,7 @@ recognition.onend = function(){
     reset();
     micmodal.classList.remove("active");
     micimg.setAttribute("src","images/mic.gif");
-}; 
+};
 
 recognition.onresult = function (event) {
     var interimText=" ";
@@ -435,7 +444,7 @@ function check(){
         chrome.storage.sync.set({"darktheme": false}, () => {
         });
     }
-    
+
     var box = document.getElementById("box");
     box.classList.toggle("box-modified");
     var field = document.getElementById("field");


### PR DESCRIPTION
Fixes #144 

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia) and my PR follows them.
- [x] My branch is up-to-date with the Upstream `master` branch.
- [x] The unit tests pass locally with my changes <!-- use `nosetests tests/unittests` to run all the tests -->
- [x] I have added necessary documentation (if appropriate)

#### Short description of what this resolves:
Adds a context menu - "Ask SUSI". User can select any text in any webpage, right click on it, select "Ask SUSI" option. The query will be visible in the SUSI popup, when the user will open the popup. (programmatic opening of the extension's popup is not supported in chrome. See [here](https://stackoverflow.com/questions/5544256/chrome-extensionhow-to-pragmatically-open-the-popup-window-from-background-htm) )

#### Changes proposed in this pull request:
- add "contextMenus" permission in `manifest.json` file.
- Add a context menu "Ask SUSI".
- Asks SUSI for the selected text.
- Add a badge(`*`) in the icon of the extension when the user clicks on the context menu, indicating unread message.
- Remove the badge from the icon of the extension when the user opens the extension.

#### screenshot:
![screenshot from 2017-10-23 03-00-59](https://user-images.githubusercontent.com/17807257/31866768-297f47c2-b7a2-11e7-8ff5-1d70000b926f.png)
