### PR TITLE
Fixes #150 : Add padding in between scroll-bar and messages

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -62,11 +62,13 @@ body {
 
 .box {
     background-color: rgb(243, 242, 244);
+    padding-right: 10px;
 }
 
 .messages {
     overflow-y: auto;
     height: 250px;
+    padding-right: 10px;
 }
 
 .mynewmessage {


### PR DESCRIPTION
<!--
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->
<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #150 

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia) and my PR follows them.
- [x] My branch is up-to-date with the Upstream `master` branch.
- [x] The unit tests pass locally with my changes <!-- use `nosetests tests/unittests` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
<!-- If an existing function does not have a docstring, please add one -->
- [ ] All the functions created/modified in this PR contain relevant docstrings.

#### Short description of what this resolves:
The scroll-bar and messages are too close, leaving extra space on the right side of scroll-bar

#### Changes proposed in this pull request:
- Add padding in between scroll-bar and messages

#### Screenshot after the UI fix
![scroll](https://user-images.githubusercontent.com/12656846/31880194-73dbed38-b7fd-11e7-96f0-a9251c35c529.png)
