### PR TITLE
Fixes #161 : Add settings for enabling options in manifest

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -10,6 +10,7 @@
        "default_title" : "susi_ai (Alt+Shift+S)",
        "default_popup" : "popup.html"
     },
+    "options_page": "options.html",
     "background": {
     "scripts": ["background.js"],
     "persistent": false
@@ -27,7 +28,6 @@
     "content_security_policy": "script-src 'self' https://api.susi.ai; object-src 'self'",
     "permissions":[
       "storage",
-      "contextMenus",
       "http://*/*",
       "https://*/*",
       "http://ajax.googleapis.com/ajax/libs/jquery/"


### PR DESCRIPTION
Fixes #161 

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia) and my PR follows them.
- [x] My branch is up-to-date with the Upstream `nextgen` branch.
- [x] The unit tests pass locally with my changes <!-- use `nosetests tests/unittests` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
<!-- If an existing function does not have a docstring, please add one -->
- [ ] All the functions created/modified in this PR contain relevant docstrings.

#### Short description of what this resolves:
Options button is disabled when we right-click on the extension icon. Make changes to enable options for the extension.

#### Changes proposed in this pull request:

- Added settings in the manifest for enabling options

@mariobehling @zamhaq @ms10398 Please review :)
