### PR TITLE
Fix #167 - apply dark theme to loading message

### DIFF
--- a/src/script.js
+++ b/src/script.js
@@ -38,6 +38,7 @@ function getCurrentTime() {
     return time;
 }
 
+
 function loading(condition=true){
     if(condition === true){
         var newDiv = document.createElement("div");
@@ -45,7 +46,13 @@ function loading(condition=true){
         newImg.setAttribute("src","images/loading.gif");
         newImg.setAttribute("style","height:10px;width:auto");
         newDiv.appendChild(newImg);
-        newDiv.setAttribute("class","susinewmessage");
+        if(dark === true)
+        {
+            newDiv.setAttribute("class","susinewmessage message-dark");
+        }
+        else{
+            newDiv.setAttribute("class","susinewmessage");
+        }
         messages.appendChild(newDiv);
         messages.scrollTop = messages.scrollHeight;
     }
@@ -80,6 +87,7 @@ chrome.storage.sync.get("message",(items) => {
     if(items){
      storageItems=items.message;
      restoreMessages(storageItems);
+
  }
 });
 
@@ -258,12 +266,12 @@ function getResponse(query) {
         },
         success: function (data) {
             data.answers[0].actions.map((action) => {
-                var response = composeResponse(action,data.answers[0].data);
-                loading(false);
-                composeSusiMessage(response);
-                if(action.type !== data.answers[0].actions[data.answers[0].actions.length-1].type){
-                    loading(); //if not last action then create another loading box for susi response
-                }
+            var response = composeResponse(action,data.answers[0].data);
+            loading(false);
+            composeSusiMessage(response);
+            if(action.type !== data.answers[0].actions[data.answers[0].actions.length-1].type){
+                loading(); //if not last action then create another loading box for susi response
+            }
             });
         }
     });


### PR DESCRIPTION
Fixes #167 

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia) and my PR follows them.
- [x] My branch is up-to-date with the Upstream `master` branch.
- [x] The unit tests pass locally with my changes <!-- use `nosetests tests/unittests` to run all the tests -->
- [x] I have added necessary documentation (if appropriate)

#### Short description of what this resolves:
Apply dark theme on the loading icon message
![screenshot from 2017-11-02 11-58-33](https://user-images.githubusercontent.com/17807257/32312838-dadc9dbe-bfc5-11e7-9b28-c46a022d289c.png)

#### Changes proposed in this pull request:
- Check if dark theme is enabled or not. 
- If it is enabled, apply it to the loading message
- If it is not enabled, apply the light theme to the loading message
