### PR TITLE
[FIX] Added fix to handle failure scenario when susi returns with no …

### DIFF
--- a/src/script.js
+++ b/src/script.js
@@ -246,14 +246,21 @@ function getResponse(query) {
             composeSusiMessage(response);
         },
         success: function (data) {
-            data.answers[0].actions.map((action) => {
-                var response = composeResponse(action,data.answers[0].data);
-                loading(false);
-                composeSusiMessage(response);
-                if(action.type !== data.answers[0].actions[data.answers[0].actions.length-1].type){
-                    loading(); //if not last action then create another loading box for susi response
-                }
-            });
+        	if (data.answers && data.answers[0]) {
+        		data.answers[0].actions.map((action) => {
+		            var response = composeResponse(action,data.answers[0].data);
+		            loading(false);
+		            composeSusiMessage(response);
+		            if(action.type !== data.answers[0].actions[data.answers[0].actions.length-1].type){
+		                loading(); //if not last action then create another loading box for susi response
+		            }
+		        });
+        	} else {
+        		composeResponse({
+        			type: 'answer',
+        			expression: 'SUSI could not find an answer to your question.'
+        		});
+        	}
         }
     });
 }


### PR DESCRIPTION
…answer

Fixes #141 

#### Checklist

- [ ] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia) and my PR follows them.
- [ ] My branch is up-to-date with the Upstream `master` branch.
- [ ] The unit tests pass locally with my changes <!-- use `nosetests tests/unittests` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
<!-- If an existing function does not have a docstring, please add one -->
- [ ] All the functions created/modified in this PR contain relevant docstrings.

#### Short description of what this resolves:
In case the SUSI server returns with no answers it used to throw an error and the loading state used to continue infinitely. This fix resolves that and speaks out a predefined message.

![image](https://user-images.githubusercontent.com/13390045/32702046-c022bd8e-c806-11e7-9f83-1f13e9c57bb2.png)


#### Changes proposed in this pull request:
- Fix when SUSI server returns with no response.