### PR TITLE
Now the json export button exports old chat history

### DIFF
--- a/src/script.js
+++ b/src/script.js
@@ -278,7 +278,12 @@ function composeSusiMessage(response) {
     chrome.storage.sync.get("message", (items) => {
         if (items.message) {
             storageArr = items.message;
+            var temp = storageArr.map(x => $.parseHTML(x.content) );
+            var messageTest = temp.map((x,i) => "message =" + x[0].innerHTML  + ", time= " + x[2].innerHTML + ((i%2 ===0)?"message by user":" message by susi") );
             console.log("this was true");
+            exportArr.push({
+                oldmessages: messageTest
+              });
         }
         storageArr.push(storageObj);
         chrome.storage.sync.set({


### PR DESCRIPTION
<!--
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->
<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #241

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia) and my PR follows them.
- [x] My branch is up-to-date with the Upstream `master` branch.
- [x] The unit tests pass locally with my changes <!-- use `nosetests tests/unittests` to run all the tests -->
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
<!-- If an existing function does not have a docstring, please add one -->
- [x] All the functions created/modified in this PR contain relevant docstrings.

#### Short description of what this resolves:
Previously the old chat history was not exported

#### Changes proposed in this pull request:
Now the old chat history is also exported