### PR TITLE
Remove wrong check if user is logged in.

### DIFF
--- a/src/script.js
+++ b/src/script.js
@@ -477,7 +477,7 @@ window.onload = function() {
 
     chrome.storage.sync.get("loggedUser", function(userDetails) {
         var log = document.getElementById("log");
-        if (accessToken && userDetails.loggedUser.email) {
+        if (userDetails.loggedUser.email) {
             accessToken = userDetails.loggedUser.accessToken;
             log.innerHTML = log.innerHTML.replace("Login", "Logout");
             log.innerHTML = log.innerHTML.replace("login.svg", "logout.png");


### PR DESCRIPTION
<!--
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->
<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->
Fixes #323

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia) and my PR follows them.
- [x] My branch is up-to-date with the Upstream `master` branch.
- [x] The unit tests pass locally with my changes <!-- use `nosetests tests/unittests` to run all the tests -->
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
<!-- If an existing function does not have a docstring, please add one -->
- [x] All the functions created/modified in this PR contain relevant docstrings.

#### Short description of what this resolves:
Earlier we had overlapping message on previous chat. Also although I was logged in, it was showing `log in` option in dropdown, Instead it should have been `Logout`.
![hello_there](https://user-images.githubusercontent.com/20624380/45886825-b9f10980-bdd7-11e8-8b35-730db81183d5.PNG)


#### Changes proposed in this pull request:
Solved this. It will check if user email if logged in and then set the access token. Earlier it was checking access token and user email, but access token wasn't present at all/set!
![fixlogoutissue](https://user-images.githubusercontent.com/20624380/45886814-b493bf00-bdd7-11e8-9935-e379b3277bb0.PNG)

