### PR TITLE
Add stack order of dropdown higher than scroll icon

### DIFF
--- a/src/popup.html
+++ b/src/popup.html
@@ -28,7 +28,7 @@
           <span class="slider round"></span>
           </label>
           </div>
-        <div class="dropdown">
+        <div style="z-index: 2;" class="dropdown">
             <div id="dropdown"><img src="images/dots.png" style="width: auto; height: 20px;"></div>
             <div class="dropdown-content">
                 <a href="https://chat.susi.ai/overview" target="_blank"><li>About<img src="images/about.svg" ></li></a>
@@ -52,7 +52,7 @@
             <div class="messages" id="messages">
             </div>
         </div>
-        <span class="scroll-icon" id="scrollIcon">
+        <span style="z-index: 1;" class="scroll-icon" id="scrollIcon">
         <svg viewBox="0 0 24 24" style="display: inline-block; color: rgb(255, 255, 255); fill: rgb(255, 255, 255); height: 30px; width: 24px; user-select: none; transition: all 450ms cubic-bezier(0.23, 1, 0.32, 1) 0ms; line-height: 40px;"><path d="M16.59 8.59L12 13.17 7.41 8.59 6 10l6 6 6-6z"></path></svg>
         </span>
         <form id="formid">


### PR DESCRIPTION
<!--
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->
<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #332 

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia) and my PR follows them.
- [x] My branch is up-to-date with the Upstream `master` branch.
- [x] The unit tests pass locally with my changes <!-- use `nosetests tests/unittests` to run all the tests -->
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
<!-- If an existing function does not have a docstring, please add one -->
- [x] All the functions created/modified in this PR contain relevant docstrings.

#### Short description of what this resolves:
Now scroll icon is below the dropdown.

#### Changes proposed in this pull request:

- Changed the z-index of dropdown to 2, and of scroll icon to 1.
![image](https://user-images.githubusercontent.com/20624380/45926302-0145da00-bf3f-11e8-8215-a936398282f3.png)

- not able to Change stack-order/ z-index property even after setting up the propoerty to 1;
refer https://leafletjs.com/reference-1.3.4.html#tilelayer-zindex
