### PR TITLE
 Correct change Password form size

### DIFF
--- a/src/css/login.css
+++ b/src/css/login.css
@@ -73,5 +73,5 @@ label {
 }
 
 .fmargin {
-    margin-top: 4%;
+    margin: 4% auto auto;
 }

--- a/src/login.html
+++ b/src/login.html
@@ -46,19 +46,26 @@
                     </div>
                     <div class="loggedin" id="loggedin">
                         <button class="btn btn-success" name="Logout" onClick="logout(this)" id="logout">Logout</button>
-                        <br />
-                        <a  style="margin-left:35%; color:#fff;"  id="pass" href="#" >Click here to change password</a>
+                        <br/>
+                        <div style="text-align: center">
+                            <a style="color:#fff;"  id="pass" href="#" >Click here to change password</a>
+                        </div>
                     </div>
                      
-                    <div style="margin-left: 27%; margin-top: 3%;" >
                     <form id="cPass" style="display:none;">
-                        <input type="email" id="cemail" placeholder="Email" class="fmargin" required>
-                        <input type="password" id="cpassword" placeholder="Password" class="fmargin" required>
-                        <input type="password" id="newPassword" placeholder="NewPassword" class="fmargin" required>                    
-                        <input type="submit" class="btn btn-success fmargin" style="width:330px;">
-
+                        <div class="form-group">
+                            <input type="email" class="form-control fmargin" id="cemail" placeholder="Email">
+                        </div>
+                        <div class="form-group">
+                            <input type="password" class="form-control fmargin" id="cpassword" placeholder="Password">
+                        </div>
+                        <div class="form-group">
+                            <input type="password" class="form-control fmargin" id="newPassword" placeholder="New Password">
+                        </div>
+                        <div style="text-align: center">
+                            <input type="submit" style="width: 20rem;" class="btn btn-success fmargin">
+                        </div>
                     </form>
-                </div>
             </div>
             <div class="col-md-2">
             </div>


### PR DESCRIPTION
<!--
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->
<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #346 

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia) and my PR follows them.
- [x] My branch is up-to-date with the Upstream `master` branch.
- [x] The unit tests pass locally with my changes <!-- use `nosetests tests/unittests` to run all the tests -->
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
<!-- If an existing function does not have a docstring, please add one -->
- [x] All the functions created/modified in this PR contain relevant docstrings.

#### Short description of what this resolves:
Corrects the sizing of only misaligned `change password` form on small-screen size.

#### Changes proposed in this pull request:
- changed Placeholder from `NewPassword` to `New Password`.
-  Resize the form, add auto margin.
- Center the link `Click here to change password`.
**changes done**:
![image](https://user-images.githubusercontent.com/20624380/45926801-e165e480-bf45-11e8-876a-a1b7d8403ef5.png)

![image](https://user-images.githubusercontent.com/20624380/45926808-0f4b2900-bf46-11e8-9c67-a83ae82bf476.png)


