### PR TITLE
Add Susi Chat, Susi Skills shortcut in Option menu #343

### DIFF
--- a/src/js/background.js
+++ b/src/js/background.js
@@ -12,6 +12,18 @@ var askSusi = chrome.contextMenus.create({
 	id:"askSusi"
 });
 
+var goToChat = chrome.contextMenus.create({
+	"title": "Chat SUSI",
+	"contexts":["browser_action"],
+	id:"goToChatSusi"
+});
+
+var goToSkills = chrome.contextMenus.create({
+	"title": "Skills SUSI",
+	"contexts":["browser_action"],
+	id:"goToSkillsSusi"
+});
+
 // perform action on clicking a context menu
 chrome.contextMenus.onClicked.addListener(function(info,tab){
 	var menuId = info.menuItemId;
@@ -21,6 +33,15 @@ chrome.contextMenus.onClicked.addListener(function(info,tab){
 			"askSusiQuery":query
 		});
 		chrome.browserAction.setBadgeText({text: "*"});
+	}
+	else if(menuId==="goToChatSusi"){
+		var chatURL = "https://chat.susi.ai";
+    	chrome.tabs.create({ url: chatURL });
+	}
+
+	else{
+		var skillURL = "https://skills.susi.ai";
+    	chrome.tabs.create({ url: skillURL });
 	}
 
 });

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -28,7 +28,8 @@
     "content_security_policy": "script-src 'self' https://api.susi.ai; object-src 'self'",
     "permissions":[
       "storage",
-      "contextMenus"
+      "contextMenus",
+      "tabs"
     ],
 
     "commands": {


### PR DESCRIPTION
<!--
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->
<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #343

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia) and my PR follows them.
- [x] My branch is up-to-date with the Upstream `master` branch.
- [x] The unit tests pass locally with my changes <!-- use `nosetests tests/unittests` to run all the tests -->
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
<!-- If an existing function does not have a docstring, please add one -->
- [x] All the functions created/modified in this PR contain relevant docstrings.

#### Short description of what this resolves:

Option to go to https://chat.susi.ai , https://skills.susi.ai

####Screenshot

<img width="321" alt="screen shot 2018-09-24 at 6 12 11 pm" src="https://user-images.githubusercontent.com/18073126/45952728-886d7d80-c025-11e8-8aa3-a05e192e3046.png">


#### Changes proposed in this pull request:

- Created context menu
- Context event listener to open a new tab in chrome
