### PR TITLE
Add minimum password limit for the user

### DIFF
--- a/src/css/login.css
+++ b/src/css/login.css
@@ -57,6 +57,10 @@ label {
     margin-right: 10px;
 }
 
+#passwordlim{
+    color: white;
+}
+
 #loggedin{
     margin-top: 15px;
 }

--- a/src/css/signup.css
+++ b/src/css/signup.css
@@ -44,3 +44,7 @@ label {
 #email, #password{
     width: 100%;
 }
+
+#passwordlim{
+	color: white;
+}

--- a/src/js/login.js
+++ b/src/js/login.js
@@ -16,6 +16,7 @@ var pass = document.getElementById("pass");
 var cPass = document.getElementById("cPass");
 var cemail = document.getElementById("cemail");
 var cpassword = document.getElementById("cpassword");
+var passwordlim = document.getElementById("passwordlim");
 var newPassword = document.getElementById("newPassword");
 var toggle = document.getElementById("toggle");
 
@@ -39,6 +40,14 @@ toggle.addEventListener("click", ()=>{
 
 pass.addEventListener("click", ()=>{
 $("#cPass").toggle();
+});
+
+newPassword.addEventListener("keyup", ()=>{
+    if(newPassword.value.length<6){
+        passwordlim.removeAttribute("hidden");
+    } else {
+        passwordlim.setAttribute("hidden", "true");
+    }
 });
 
 cPass.addEventListener("submit", (e)=>{

--- a/src/js/login.js
+++ b/src/js/login.js
@@ -45,8 +45,10 @@ $("#cPass").toggle();
 newPassword.addEventListener("keyup", ()=>{
     if(newPassword.value.length<6){
         passwordlim.removeAttribute("hidden");
+        document.getElementById("csubmit").setAttribute("disabled", "true");        
     } else {
         passwordlim.setAttribute("hidden", "true");
+        document.getElementById("csubmit").removeAttribute("disabled");
     }
 });
 

--- a/src/js/signup.js
+++ b/src/js/signup.js
@@ -22,9 +22,11 @@ function showsignupBlock(show){
 
 cpassword.addEventListener("keyup", ()=>{
     if(cpassword.value.length<6){
-        passwordlim.removeAttribute("hidden");
+		passwordlim.removeAttribute("hidden");
+		document.getElementById("signupbutton").setAttribute("disabled", "true");
     } else {
-        passwordlim.setAttribute("hidden", "true");
+		passwordlim.setAttribute("hidden", "true");
+		document.getElementById("signupbutton").removeAttribute("disabled");	
     }
 });
 

--- a/src/js/signup.js
+++ b/src/js/signup.js
@@ -3,6 +3,7 @@ var signupForm = document.getElementById("signupForm");
 var notsignupBlock = document.getElementById("notsignup");
 var signupBlock = document.getElementById("signedup");
 var BASE_URL = "https://api.susi.ai";
+var passwordlim = document.getElementById("passwordlim");
 
 window.onload = function(){
 	showsignupBlock(true);
@@ -18,6 +19,14 @@ function showsignupBlock(show){
 		notsignupBlock.style.display="none";
 	}
 }
+
+cpassword.addEventListener("keyup", ()=>{
+    if(cpassword.value.length<6){
+        passwordlim.removeAttribute("hidden");
+    } else {
+        passwordlim.setAttribute("hidden", "true");
+    }
+});
 
 signupForm.addEventListener("submit", function reset(event){
 	event.preventDefault();

--- a/src/login.html
+++ b/src/login.html
@@ -66,7 +66,7 @@
                             </div>
                         </div>
                         <div style="text-align: center">
-                            <input type="submit" style="width: 20rem;" class="btn btn-success fmargin">
+                            <input disabled type="submit" id="csubmit" style="width: 20rem;" class="btn btn-success fmargin">
                         </div>
                     </form>
             </div>

--- a/src/login.html
+++ b/src/login.html
@@ -61,6 +61,9 @@
                         </div>
                         <div class="form-group">
                             <input type="password" class="form-control fmargin" id="newPassword" placeholder="New Password">
+                            <div style="text-align: center">
+                                <small hidden id="passwordlim">Minimum 6 characters required</small>
+                            </div>
                         </div>
                         <div style="text-align: center">
                             <input type="submit" style="width: 20rem;" class="btn btn-success fmargin">

--- a/src/signup.html
+++ b/src/signup.html
@@ -23,6 +23,9 @@
                             <div class="form-group">
                                 <label for="password">Password:</label>
                                 <input type="password" class="form-control" id="cpassword" placeholder="Enter your password">
+                                <div style="text-align: center">
+                                    <small hidden id="passwordlim">Minimum 6 characters required</small>
+                                </div>
                             </div>
                             <br />
                             <div class="form-group">

--- a/src/signup.html
+++ b/src/signup.html
@@ -33,7 +33,7 @@
                                 <input type="password" class="form-control" id="password" placeholder="Confirm Password">
                             </div>
                             <br>
-                            <button type="submit" class="btn btn-success" id="signupbutton">Signup</button>
+                            <button disabled type="submit" class="btn btn-success" id="signupbutton">Signup</button>
                             <br>
                             <p style="text-align: center;">
                                 <a href="login.html" style="color: #fff; ">Already Registered? Want to Login</a>


### PR DESCRIPTION
<!--
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->
<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #326 

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia) and my PR follows them.
- [x] My branch is up-to-date with the Upstream `master` branch.
- [x] The unit tests pass locally with my changes <!-- use `nosetests tests/unittests` to run all the tests -->
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
<!-- If an existing function does not have a docstring, please add one -->
- [x] All the functions created/modified in this PR contain relevant docstrings.

#### Short description of what this resolves:
it gives a user info about `minimum password limit of 6`, both at setting up new password (at signup) and changing password (in change password form). Help text gets removed, if user enters characters greater than 5.

#### Changes proposed in this pull request:

- Color of warning/infp text is set to white, as `red` is not showing up clearly on a blue background.
- Text is centered.

![image](https://user-images.githubusercontent.com/20624380/46022325-069e5280-c100-11e8-8f91-91aef39d805d.png)
![image](https://user-images.githubusercontent.com/20624380/46022398-20d83080-c100-11e8-9fec-4f51183fa829.png)

