### PR TITLE
Respond with text if Response Empty #373, Table Cut #358

### DIFF
--- a/src/css/login.css
+++ b/src/css/login.css
@@ -48,13 +48,25 @@ label {
     margin : auto;
 }
 
+.fa-eye, .fa-eye-slash{
+    position: absolute;
+    top: 6px;
+    right: 5px;
+    z-index: 15;
+    display: block;
+    width: 34px;
+    height: 34px;
+    line-height: 34px;
+    text-align: center;
+}
+
 #username{
     width: 100%;
 }
 
 #password{
     width: 100%;
-    margin-right: 10px;
+    border-radius: 0.25rem;
 }
 
 #loggedin{
@@ -66,7 +78,7 @@ label {
     margin:auto;
     padding:7px;
     text-align: center;
-  }
+}
 
 #cPass input {
     width: 60%;

--- a/src/script.js
+++ b/src/script.js
@@ -144,6 +144,7 @@ function composeReplyTable(response, columns, data) {
                     trItem.appendChild(tdItem);
                 } else {
                     tdItem.appendChild(document.createTextNode(item[key]));
+                    tdItem.setAttribute("class", "table-tweet-response");
                     trItem.appendChild(tdItem);
                 }
             }
@@ -331,6 +332,18 @@ let queryUrl = "";
 let baseUrl = "https://api.susi.ai/susi/chat.json?timezoneOffset=-300&q=";
 
 function getResponse(query) {
+    var errorResponse = {
+        error: true,
+        errorText: "Sorry! request could not be made"
+    };
+
+    var noResponse = {
+        error: true,
+        errorText: "Hmm... I'm not sure if i understand you correctly."
+    };
+
+    var timestamp = getCurrentTime();
+
     loading();
     if (accessToken) {
         queryUrl = `${baseUrl}${query}&access_token=${accessToken}`;
@@ -347,17 +360,19 @@ function getResponse(query) {
             console.log(textStatus);
             console.log(errorThrown);
             loading(false);
-            var response = {
-                error: true,
-                errorText: "Sorry! request could not be made"
-            };
-            composeSusiMessage(response);
+            composeSusiMessage(errorResponse);
         },
         success: function(data) {
-            successResponse(data);
+            if(!data.answers[0]){
+                loading(false);
+                composeSusiMessage(noResponse, timestamp);
+            }
+            else {
+                successResponse(data);
+            }
+            
         }
     });
-
 }
 
 function composeMyMessage(text, t= getCurrentTime()) {

--- a/src/style.css
+++ b/src/style.css
@@ -562,3 +562,10 @@ th {
     height: 200px;
     width: 200px;
 }
+
+.table-tweet-response{
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: normal;
+    width: 80px;
+}


### PR DESCRIPTION
<!--
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->
<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #373, #358, #378 

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia) and my PR follows them.
- [x] My branch is up-to-date with the Upstream `master` branch.
- [x] The unit tests pass locally with my changes <!-- use `nosetests tests/unittests` to run all the tests -->
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
<!-- If an existing function does not have a docstring, please add one -->
- [x] All the functions created/modified in this PR contain relevant docstrings.

#### Short description of what this resolves:
On typing something gibberish or like random letters, no response is fetched(only loading). Now a response is shown.

When reply is of tweet type, the response is not cutoff from right side now.

The eye is inside the password field.

Screenshot:

For non response
<img width="341" alt="screen shot 2018-09-27 at 2 38 56 pm" src="https://user-images.githubusercontent.com/18073126/46135741-83960d00-c263-11e8-9e38-8a25c5f231a2.png">

For table:
<img width="349" alt="screen shot 2018-09-27 at 5 02 16 pm" src="https://user-images.githubusercontent.com/18073126/46143337-4176c680-c277-11e8-9f59-34d6b21187f2.png">

For eye:
<img width="774" alt="screen shot 2018-09-28 at 1 32 49 am" src="https://user-images.githubusercontent.com/18073126/46171576-8b36cf80-c2be-11e8-8ad0-f35c1b4e21bd.png">

#### Changes proposed in this pull request:

- On typing something gibberish or like random letters, `Respond with Hmm... I'm not sure if i understand you correctly.`
- Fixed table tweet response text, it wont cut like it used to earlier.
- Fix the eye inside input field