### PR TITLE
exchange ID names of cpassword with password.

### DIFF
--- a/src/js/signup.js
+++ b/src/js/signup.js
@@ -4,6 +4,7 @@ var notsignupBlock = document.getElementById("notsignup");
 var signupBlock = document.getElementById("signedup");
 var BASE_URL = "https://api.susi.ai";
 var passwordlim = document.getElementById("passwordlim");
+var password = document.getElementById("password");
 
 window.onload = function(){
 	showsignupBlock(true);
@@ -20,8 +21,8 @@ function showsignupBlock(show){
 	}
 }
 
-cpassword.addEventListener("keyup", ()=>{
-    if(cpassword.value.length<6){
+password.addEventListener("keyup", ()=>{
+    if(password.value.length<6){
 		passwordlim.removeAttribute("hidden");
 		document.getElementById("signupbutton").setAttribute("disabled", "true");
     } else {

--- a/src/signup.html
+++ b/src/signup.html
@@ -22,7 +22,7 @@
                             <br />
                             <div class="form-group">
                                 <label for="password">Password:</label>
-                                <input type="password" class="form-control" id="cpassword" placeholder="Enter your password">
+                                <input type="password" class="form-control" id="password" placeholder="Enter your password">
                                 <div style="text-align: center">
                                     <small hidden id="passwordlim">Minimum 6 characters required</small>
                                 </div>
@@ -30,7 +30,7 @@
                             <br />
                             <div class="form-group">
                                 <label for="password">Confirm Password:</label>
-                                <input type="password" class="form-control" id="password" placeholder="Confirm Password">
+                                <input type="password" class="form-control" id="cpassword" placeholder="Confirm Password">
                             </div>
                             <br>
                             <button disabled type="submit" class="btn btn-success" id="signupbutton">Signup</button>


### PR DESCRIPTION
<!--
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->
<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #379 

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia) and my PR follows them.
- [x] My branch is up-to-date with the Upstream `master` branch.
- [x] The unit tests pass locally with my changes <!-- use `nosetests tests/unittests` to run all the tests -->
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
<!-- If an existing function does not have a docstring, please add one -->
- [x] All the functions created/modified in this PR contain relevant docstrings.

#### Short description of what this resolves:
**Earlier** id `cpassword` was used in setting up password field on sign up form.
Whereas id `password` was used in confirmation password field on sign up form.
Refer https://github.com/fossasia/susi_chromebot/blob/b9af60cade7b8d054754f923dc77a4379d333a5f/src/signup.html#L25

https://github.com/fossasia/susi_chromebot/blob/b9af60cade7b8d054754f923dc77a4379d333a5f/src/signup.html#L30

#### Changes proposed in this pull request:

- Now, made the  `password` id for **password** field and `cpassword` id for **confirm password** field.
- Change corresponding Javascript file.
------
@zamhaq @gabru-md @ms10398 @stealthanthrax please review.
