### PR TITLE
Stop SUSI from speaking out earlier messages on login.

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -19,7 +19,7 @@
      "trailing": true,
      "maxparams": 3, 
      "maxdepth": 4, 
-     "maxstatements": 50, 
+     "maxstatements": 60,
      "jquery": true, 
      "browser": true, 
      "devel": true, 

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -8,7 +8,7 @@ module.exports = function (grunt) {
       options: { bitwise: true, camelcase: true, curly: true, eqeqeq: true, forin: true, immed: true,
           indent: 4, latedef: true, newcap: true, noarg: true, noempty: true, nonew: true, plusplus: false,
           quotmark: true, regexp: true, undef: true, unused: true, trailing: true,
-          maxparams: 3, maxdepth: 4, maxstatements: 50, jquery: true, browser: true, devel: true, moz:true, strict: false,
+          maxparams: 3, maxdepth: 4, maxstatements: 60, jquery: true, browser: true, devel: true, moz:true, strict: false,
           esversion: 6},
       all: [
           'Gruntfile.js',

--- a/src/script.js
+++ b/src/script.js
@@ -16,6 +16,7 @@ var exportData = document.getElementById("export");
 var dark = false;
 var upCount = 0;
 var shouldSpeak = true;
+var isOlderMessage = false;
 var storageItems = [];
 var storageArr = [];
 var exportArr = [];
@@ -245,13 +246,13 @@ function composeSusiMessage(response, t, rating) {
         susiTextNode = document.createTextNode(response.errorText);
         newP.appendChild(susiTextNode);
         newDiv.appendChild(newP);
-        speakOutput(response.errorText, shouldSpeak);
+        speakOutput(response.errorText, shouldSpeak && !isOlderMessage);
     } else {
         if (response.reply && !response.image) {
             susiTextNode = document.createTextNode(response.reply);
             newP.appendChild(susiTextNode);
             newDiv.appendChild(newP);
-            speakOutput(response.reply, shouldSpeak);
+            speakOutput(response.reply, shouldSpeak && !isOlderMessage);
         } else if (response.image) {
             var newImg = composeImage(response.reply);
             newDiv.appendChild(document.createElement("br"));
@@ -271,6 +272,10 @@ function composeSusiMessage(response, t, rating) {
         else {
             console.log("could not make response");
         }
+    }
+    if (isOlderMessage) {
+        // reset isOlderMessage
+        isOlderMessage = false;
     }
     exportArr.push({
         time: t,
@@ -402,12 +407,13 @@ function generateRating(skill) {
     return null;
 }
 
-function successResponse(data , timestamp = getCurrentTime()) {
+function successResponse(data , timestamp = getCurrentTime(), speak = true) {
     data.answers[0].actions.map((action) => {
         var response = composeResponse(action, data.answers[0].data);
         let skill = data.answers[0].skills[0];
         let rating = generateRating(skill);
         loading(false);
+        isOlderMessage = !speak;
         composeSusiMessage(response, timestamp, rating);
         if (action.type !== data.answers[0].actions[data.answers[0].actions.length - 1].type) {
             loading(); //if not last action then create another loading box for susi response
@@ -550,7 +556,7 @@ function syncMessagesFromServer() {
             var garbageElement = `<div class="mynewmessage"><p></p><br><p class="time"></p></div>`;
             $(".empty-history").remove();
             messages.insertAdjacentHTML("beforeend", garbageElement);
-            successResponse(answer, answerTime);
+            successResponse(answer, answerTime, false);
         }
         queryAnswerData = null;
         localStorage.setItem("messages", null);
@@ -591,15 +597,12 @@ window.onload = function() {
     });
     syncMessagesFromServer();
     chrome.storage.sync.get("message", (items) => {
-    if (items) {
-        storageItems = items.message;
-        restoreMessages(storageItems);
-
-    }
-    else
-    {
-	  		$(".empty-history").remove();
-	 }
+        if (items) {
+            storageItems = items.message;
+            restoreMessages(storageItems);
+        } else {
+            $(".empty-history").remove();
+        }
 	});
 };
 


### PR DESCRIPTION
<!--
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->
<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #289 

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia) and my PR follows them.
- [x] My branch is up-to-date with the Upstream `master` branch.
- [x] The unit tests pass locally with my changes <!-- use `nosetests tests/unittests` to run all the tests -->
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
<!-- If an existing function does not have a docstring, please add one -->
- [x] All the functions created/modified in this PR contain relevant docstrings.

#### Short description of what this resolves:
 Bot speaks out every reply from the start on re-install/re-login. Now it wouldn't happen.

#### Changes proposed in this pull request:

-  if messages are being synced from the server, then `successResponse` should be called with speak set to false. And thus susi will not speak older messages. Default value of `speak` is set to true, for all other cases.
