### PR TITLE
Fix typo. Replace 'out' with 'our'

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,7 +1,7 @@
 **I'm submitting a ...**  (check one with "x")
 - [ ] bug report
 - [ ] feature request
-- [ ] support request => Please do not submit support requests here, instead ask your query in out Gitter channel at https://gitter.im/fossasia/susi_server
+- [ ] support request => Please do not submit support requests here, instead ask your query in our [Gitter channel](https://gitter.im/fossasia/susi_server)
 
 **Current behavior:**
 <!-- Describe how the bug manifests. -->


### PR DESCRIPTION
<!--
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->
<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #330 - using the old issue for this PR.

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia) and my PR follows them.
- [x] My branch is up-to-date with the Upstream `master` branch.
- [x] The unit tests pass locally with my changes <!-- use `nosetests tests/unittests` to run all the tests -->
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
<!-- If an existing function does not have a docstring, please add one -->
- [x] All the functions created/modified in this PR contain relevant docstrings.

#### Short description of what this resolves:
Typo

#### Changes proposed in this pull request:

- Should be `our` instead of `out`.
