### PR TITLE
Fix Console Error #382, message type Map #366, Persist Susi Reply#402

### DIFF
--- a/src/js/login.js
+++ b/src/js/login.js
@@ -73,7 +73,7 @@ cPass.addEventListener("submit", (e)=>{
 
 window.onload = function() {
     chrome.storage.sync.get("loggedUser", function(userDetails) {
-        if (userDetails.loggedUser.email) {
+        if (userDetails.loggedUser && userDetails.loggedUser.email) {
             var msg="You are logged in as "+userDetails.loggedUser.email;
             showStatus(msg,false);
             showLoggedInBlock(true);
@@ -97,9 +97,15 @@ function showLoggedInBlock(show) {
     if (show) {
         noLoggedInBlock.style.display = "none";
         loggedInBlock.style.display = "block";
-        document.getElementById("passwordchange").value = "";
-        document.getElementById("passwordnewconfirm").value = "";
-        document.getElementById("passwordnew").value = "";
+        if (document.getElementById("passwordchange") != null) {
+            document.getElementById("passwordchange").value = "";
+        }
+        if (document.getElementById("passwordnewconfirm") != null) {
+            document.getElementById("passwordnewconfirm").value = "";
+        }
+        if (document.getElementById("passwordnew") != null) {
+            document.getElementById("passwordnew").value = "";
+        }
     } else {
         noLoggedInBlock.style.display = "block";
         loggedInBlock.style.display = "none";

--- a/src/login.html
+++ b/src/login.html
@@ -15,8 +15,8 @@
                 <div class="card">
                     <img src="images/susi-logo.png" class="img-fluid signin-image">
                     <div class="alert alert-danger error col-md-10" id="error">
-                       Error
-                   </div>
+                        Error
+                    </div>
                     <div class="nologgedin" id="nologgedin">
                         <form id="login">
                             <div class="form-group">
@@ -45,13 +45,12 @@
                         </form>
                     </div>
                     <div class="loggedin" id="loggedin">
-                        <button class="btn btn-danger" name="Logout" onClick="logout(this)" id="logout">Logout</button>
+                        <button class="btn btn-danger" name="Logout" id="logout">Logout</button>
                         <br/>
                         <div style="text-align: center">
                             <a style="color:#fff;"  id="pass" href="#" >Click here to change password</a>
                         </div>
                     </div>
-                     
                     <form id="cPass" style="display:none;">
                         <div class="form-group">
                             <input type="email" class="form-control fmargin" id="cemail" placeholder="Email">

--- a/src/script.js
+++ b/src/script.js
@@ -299,7 +299,7 @@ function composeSusiMessage(response, t, rating) {
     var susimessage = newDiv.innerHTML;
     storageObj.content = susimessage;
     storageObj.senderClass = "susinewmessage";
-    chrome.storage.sync.get("message", (items) => {
+    chrome.storage.local.get("message", (items) => {
         if (items.message) {
             storageArr = items.message;
             var temp = storageArr.map(x => $.parseHTML(x.content));
@@ -310,7 +310,7 @@ function composeSusiMessage(response, t, rating) {
             });
         }
         storageArr.push(storageObj);
-        chrome.storage.sync.set({
+        chrome.storage.local.set({
             "message": storageArr
         }, () => {
             console.log("saved");
@@ -519,18 +519,18 @@ function composeMyMessage(text, t= getCurrentTime()) {
         image: false,
         source: "user"
     });
-    chrome.storage.sync.get("message", (items) => {
+    chrome.storage.local.get("message", (items) => {
         if (items.message) {
             storageArr = items.message;
         }
         storageArr.push(storageObj);
-        chrome.storage.sync.set({
+        chrome.storage.local.set({
             "message": storageArr
         }, () => {});
     });
 }
 
-function restoreMessages(storageItems) {
+function restoreMessages(storageItems = []) {
     if (!storageItems && !accessToken) {
         var htmlMsg = "<div class='empty-history'> Start by saying \"Hi\"</div>";
         $(htmlMsg).appendTo(messages);
@@ -601,7 +601,7 @@ window.onload = function() {
         console.log(msgTheme);
     }
 
-    chrome.storage.sync.get("loggedUser", function(userDetails) {
+    chrome.storage.local.get("loggedUser", function(userDetails) {
         var log = document.getElementById("log");
         if (userDetails.loggedUser && userDetails.loggedUser.email) {
             accessToken = userDetails.loggedUser.accessToken;
@@ -613,7 +613,7 @@ window.onload = function() {
         }
     });
     syncMessagesFromServer();
-    chrome.storage.sync.get("message", (items) => {
+    chrome.storage.local.get("message", (items) => {
         if (items) {
             storageItems = items.message;
             restoreMessages(storageItems);


### PR DESCRIPTION
<!--
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->
<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #366, #382, #402

Closed PR https://github.com/fossasia/susi_chromebot/pull/367 due to merge conflicts. The branch was older as the PR was reviewed late.

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia) and my PR follows them.
- [x] My branch is up-to-date with the Upstream `master` branch.
- [x] The unit tests pass locally with my changes <!-- use `nosetests tests/unittests` to run all the tests -->
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
<!-- If an existing function does not have a docstring, please add one -->
- [x] All the functions created/modified in this PR contain relevant docstrings.

#### Short description of what this resolves:

- The error is due to accessing the data.answers[0] which can be undefined also

- On logging in, the following console errors are present:

<img width="657" alt="screenshot 2018-09-30 at 12 24 41 am" src="https://user-images.githubusercontent.com/18073126/46249465-4e4a1480-c447-11e8-925e-1e0d8d848077.png">
<img width="638" alt="screenshot 2018-09-30 at 12 24 51 am" src="https://user-images.githubusercontent.com/18073126/46249466-4ee2ab00-c447-11e8-8960-1326e01b80e4.png">

- If message is of type map, the following console errors are given:

<img width="642" alt="screenshot 2018-09-30 at 12 25 35 am" src="https://user-images.githubusercontent.com/18073126/46249481-746fb480-c447-11e8-939d-c6c0e6365873.png">

This error comes when you use chrome.storage.sync.set.. to set the data which is more than 8,192 bytes for a single item as chrome.storage.sync.set allows 8,192 QUOTA_BYTES_PER_ITEM.

Using chrome.storage.local.set.. to set the data instead of chrome.storage.sync.set.
As chrome.storage.local.set can contains **5242880** :QUOTA_BYTES.

<img width="648" alt="screenshot 2018-09-30 at 12 25 41 am" src="https://user-images.githubusercontent.com/18073126/46249482-746fb480-c447-11e8-9ab1-a697717ad600.png">
<img width="638" alt="screenshot 2018-09-30 at 12 25 46 am" src="https://user-images.githubusercontent.com/18073126/46249483-75084b00-c447-11e8-9fc6-57a5812a92a7.png">

- On logout, following errors are given:
<img width="641" alt="screenshot 2018-09-30 at 12 27 26 am" src="https://user-images.githubusercontent.com/18073126/46249495-b00a7e80-c447-11e8-98c6-3487971f7e06.png">

Content Security Policy does not allow inline javascript. So you have to put your javascript in a .js file and include it in your HTML.

<img width="642" alt="screenshot 2018-09-30 at 12 28 10 am" src="https://user-images.githubusercontent.com/18073126/46249497-bb5daa00-c447-11e8-97e0-d6c6f113ee6b.png">


**Susi Response persistent:**

Reason for not being persistent: The chrome allows only contains 5242880 byte in chrome.storage.sync.set. Using chrome.storage.local.set. to set the data and get data, solves the 
in-persistency problem.

Old GIF of bug:
![bug-response](https://user-images.githubusercontent.com/18073126/46347546-8761cf00-c669-11e8-963c-c6de44c89783.gif)

New:
![persistent](https://user-images.githubusercontent.com/18073126/46414675-3d4c1c80-c741-11e8-9141-577c4e80494e.gif)


#### Changes proposed in this pull request:

- Fixes console error
- Fixes maps console error try:  `where is delhi`
- Susi Response Persistent