### PR TITLE
Fix -410 Removing Deprecated Stream.stop

### DIFF
--- a/src/js/options.js
+++ b/src/js/options.js
@@ -33,7 +33,7 @@ if(micAccess) {
         navigator.webkitGetUserMedia({
             audio: true
         }, function (stream) {
-            stream.stop();
+            stream.getTracks().forEach(track => track.stop());
         }, function () {
             console.log("no access");
         });


### PR DESCRIPTION
<!--
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->
<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #410 

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia) and my PR follows them.
- [x] My branch is up-to-date with the Upstream `master` branch.
- [x] The unit tests pass locally with my changes <!-- use `nosetests tests/unittests` to run all the tests -->
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
<!-- If an existing function does not have a docstring, please add one -->
- [x] All the functions created/modified in this PR contain relevant docstrings.



#### Changes proposed in this pull request:

- Using Latest Code to stop Voice Streams
