### PR TITLE
Remember voice settings

### DIFF
--- a/src/script.js
+++ b/src/script.js
@@ -884,6 +884,12 @@ let check = () => {
     $("#scrollIcon").toggleClass("scroll-dark");
 };
 
+chrome.storage.sync.get("speakcheck", (obj) => {
+  if(obj.speakcheck === false){
+    document.getElementById("speak").click();
+  }
+});
+
 let changeSpeak = () => {
     shouldSpeak = !shouldSpeak;
     var SpeakIcon = document.getElementById("speak-icon");
@@ -893,6 +899,9 @@ let changeSpeak = () => {
         SpeakIcon.innerText = "volume_up";
     }
     console.log("Should be speaking? " + shouldSpeak);
+    chrome.storage.sync.set({
+        "speakcheck": shouldSpeak
+    }, () => {});
 };
 
 scrollIconTopElement.addEventListener("click", (e) => {


### PR DESCRIPTION
Fixes #442 

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia) and my PR follows them.
- [x] My branch is up-to-date with the Upstream `master` branch.
- [x] The unit tests pass locally with my changes <!-- use `nosetests tests/unittests` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
<!-- If an existing function does not have a docstring, please add one -->
- [ ] All the functions created/modified in this PR contain relevant docstrings.

#### Short description of what this resolves:
Chrome stores the voice(speaker) settings.

#### Changes proposed in this pull request:
![voice remember](https://user-images.githubusercontent.com/32234926/47698385-25c75d00-dc35-11e8-8aa2-9b8ea206feef.gif)

