### PR TITLE
Susi chats lost after reopening the extension

### DIFF
--- a/src/script.js
+++ b/src/script.js
@@ -323,7 +323,7 @@ let composeSusiMessage = (response, t, rating) => {
         if (items.message) {
             storageArr = items.message;
             var temp = storageArr.map(x => $.parseHTML(x.content));
-            var messageTest = temp.map((x, i) => "message =" + x[0].innerHTML + ", time= " + x[2].innerHTML + ((i % 2 === 0) ? "message by user" : " message by susi"));
+            var messageTest = temp.map((x, i) => "message =" + x[0].innerHTML + ", time= " + x[1].innerText + ((i % 2 === 0) ? "message by user" : " message by susi"));
             console.log("this was true");
             exportArr.push({
                 oldmessages: messageTest


### PR DESCRIPTION
Fixes #446

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia) and my PR follows them.
- [x] My branch is up-to-date with the Upstream `master` branch.
- [x] The unit tests pass locally with my changes <!-- use `nosetests tests/unittests` to run all the tests -->
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
<!-- If an existing function does not have a docstring, please add one -->
- [x] All the functions created/modified in this PR contain relevant docstrings.

#### Short description of what this resolves:
Susi chats were getting lost because in script.js for reading the time, wrong
values were being passed which resulted in not defined error, now that bug has been fixed. 
