### PR TITLE
Change password link text varies now

### DIFF
--- a/src/js/login.js
+++ b/src/js/login.js
@@ -40,7 +40,7 @@ toggle.addEventListener("click", ()=>{
 });
 
 pass.addEventListener("click", ()=>{
-$("#cPass").toggle();
+    pass.innerHTML = ($("#cPass").toggle().is(":visible"))?("Click here to hide change password form"):("Click here to change password");
 });
 
 newPassword.addEventListener("keyup", ()=>{


### PR DESCRIPTION
<!--
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->
<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #459 

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia) and my PR follows them.
- [x] My branch is up-to-date with the Upstream `master` branch.
- [ ] The unit tests pass locally with my changes <!-- use `nosetests tests/unittests` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
<!-- If an existing function does not have a docstring, please add one -->
- [ ] All the functions created/modified in this PR contain relevant docstrings.

#### Short description of what this resolves:
Text of the link that shows/hides change password form, varies depending upon the form is shown or hidden.

#### Changes proposed in this pull request:
GIF - 
![chromebot](https://user-images.githubusercontent.com/31539812/48060330-b4158300-e1e1-11e8-996e-a1e4661803eb.gif)

-
-
-
