### PR TITLE
Background image upload now only accepts images

### DIFF
--- a/src/options.html
+++ b/src/options.html
@@ -71,7 +71,7 @@
                                     <span>Upload Local Image</span>
                                 </div>
                                 <div class="col-sm-7">
-                                    <input id="localupload"  type="file"  placeholder="Background URL" id="backUrl">
+                                    <input id="localupload"  type="file"  placeholder="Background URL" id="backUrl" accept="image/*">
                                 </div>
                             </div>
                         </form>


### PR DESCRIPTION
<!--
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->
<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #487 

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia) and my PR follows them.
- [x] My branch is up-to-date with the Upstream `master` branch.
- [ ] The unit tests pass locally with my changes <!-- use `nosetests tests/unittests` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
<!-- If an existing function does not have a docstring, please add one -->
- [ ] All the functions created/modified in this PR contain relevant docstrings.

#### Short description of what this resolves:
Background image upload now only accepts images

**Screenshots**
![ezgif com-video-to-gif 14](https://user-images.githubusercontent.com/31539812/48913359-28b51680-ee9e-11e8-8603-7be7cc40fa8a.gif)
