### PR TITLE
Alerting "success" only when some option is selected and submit is clicked in settings

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,4 +1,4 @@
-**I'm submitting a ...**  (check one with "x")
+**I'm submitting a ...**  <!-- check one with "x" -->
 - [ ] bug report
 - [ ] feature request
 - [ ] support request => Please do not submit support requests here, instead ask your query in our [Gitter channel](https://gitter.im/fossasia/susi_server)
@@ -25,11 +25,14 @@ insert any relevant code here else remove this section
 
 <!-- Add information about the system you're facing this bug on. If you think this is irrelevant or if it's a UI bug or a feature request, please remove this section -->
 
+**Screenshots of the issue:**
+<!-- Wherever applicable attach a screenshot of the issue. -->
+
 ```
 Your operating system
 ```
 
 **Would you like to work on the issue?**
 
-Please let us know if you can work on it or the issue should be assigned to someone else.
+<!-- Please let us know if you can work on it or the issue should be assigned to someone else. -->
 ```

--- a/src/css/login.css
+++ b/src/css/login.css
@@ -69,6 +69,10 @@ label {
     border-radius: 0.25rem;
 }
 
+.input-group>#password {
+    padding-right: 3rem;
+}
+
 #passwordlim{
     color: white;
 }

--- a/src/popup.html
+++ b/src/popup.html
@@ -31,14 +31,11 @@
         <div style="z-index: 2;" class="dropdown">
             <div id="dropdown"><img src="images/dots.png" style="width: auto; height: 20px;"></div>
             <div class="dropdown-content">
-                <a href="https://chat.susi.ai/" target="_blank"><li>Chat<img src="images/chat.svg"></li></a>
-                <a href="https://skills.susi.ai/" target="_blank"><li>Skills<img src="images/skills.svg"></li></a>
+                <a href="https://chat.susi.ai/overview" target="_blank"><li>About<img src="images/about.svg" ></li></a>
                 <a href="" id="clear"><li>Clear Chat<img src="images/clearAll.svg" ></li></a>
                 <a id="export"><li>Export<img src="images/export.svg"></li></a>
                 <a href="options.html" target="_blank"><li id="settings-tab">Settings<img src="images/settings.svg" ></li></a>
-                <a href="https://chat.susi.ai/overview" target="_blank"><li>About<img src="images/about.svg" ></li></a>
                 <a href="login.html" target="_blank"><li id="log">Login<img src="images/login.svg" > </li></a>
-                <a href="options.html" target="_blank"><li>Settings <img src="images/settings-icon.svg"></li></a>
             </div>
         </div>
     </header>


### PR DESCRIPTION
<!--
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->
<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia) and my PR follows them.
- [x] My branch is up-to-date with the Upstream `master` branch.
- [ ] The unit tests pass locally with my changes <!-- use `nosetests tests/unittests` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
<!-- If an existing function does not have a docstring, please add one -->
- [x] All the functions created/modified in this PR contain relevant docstrings.

#### Short description of what this resolves:
Previously in settings page when user clicks Submit button without actually changing the Message Pane Colour or Predefined themes it shows a success message.
But now success message will only be displayed when some different colour or theme is selected.

<a href="https://imgflip.com/gif/2r66th"><img src="https://i.imgflip.com/2r66th.gif" title="made at imgflip.com"/></a>
#### Changes proposed in this pull request:

-
-
-
