### PR TITLE
scrollIconTopElement is shown when message window is at bottom

### DIFF
--- a/src/script.js
+++ b/src/script.js
@@ -323,7 +323,7 @@ let composeSusiMessage = (response, t, rating) => {
         if (items.message) {
             storageArr = items.message;
             var temp = storageArr.map(x => $.parseHTML(x.content));
-            var messageTest = temp.map((x, i) => "message =" + x[0].innerHTML + ", time= " + x[1].innerText + ((i % 2 === 0) ? "message by user" : " message by susi"));
+            var messageTest = temp.map((x, i) => "message =" + x[0].innerHTML + ", time= " + x[2].innerHTML + ((i % 2 === 0) ? "message by user" : " message by susi"));
             console.log("this was true");
             exportArr.push({
                 oldmessages: messageTest
@@ -650,7 +650,7 @@ window.onload = () => {
 
 
 let handleScroll = () => {
-  var end=messages.scrollHeight - messages.scrollTop === messages.clientHeight;
+  var end = messages.scrollHeight - messages.scrollTop === messages.clientHeight;
   if(end){
     scrollIconBottomElement.style.display="none";
     scrollIconTopElement.style.display="block";


### PR DESCRIPTION
<!--
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->
<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #542

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia) and my PR follows them.
- [x] My branch is up-to-date with the Upstream `master` branch.
- [x] The unit tests pass locally with my changes <!-- use `nosetests tests/unittests` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
<!-- If an existing function does not have a docstring, please add one -->
- [ ] All the functions created/modified in this PR contain relevant docstrings.

#### Short description of what this resolves:
When a user is at the bottom of the message window then scrollIconTopElement should shown.

#### Changes proposed in this pull request:

![top](https://user-images.githubusercontent.com/32234926/59147315-90d0e180-8a17-11e9-8b5b-0fc7be74a9cc.gif)
