### PR TITLE
Solved: overlapping Issue of ScrollIcon and top margin Issue of login page

### DIFF
--- a/src/css/login.css
+++ b/src/css/login.css
@@ -7,7 +7,7 @@ body{
 }
 
 .container{
-	margin-top: 8%;
+	margin-top: 0;
 }
 
 .field-icon{

--- a/src/style.css
+++ b/src/style.css
@@ -58,7 +58,7 @@ body {
 
 .scroll-icon-bottom, .scroll-icon-top{
     position: absolute;
-    right: 20px;
+    right: 25px;
     cursor: pointer;
     bottom: 85px;
     background-color: rgb(66, 133, 244);
@@ -66,6 +66,7 @@ body {
     border-radius: 50%;
     padding-top: 5px;
     display: none;
+    opacity: 0.75;
 }
 
 .surroundbox {


### PR DESCRIPTION
overlapping of scrollIconUp/Bottom with scollbar is fixed and login page's top margin fixed.

Issue #550 and #549 is resolved kindly check it out.


Fixes #

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia) and my PR follows them.
- [x] My branch is up-to-date with the Upstream `master` branch.
- [x] The unit tests pass locally with my changes 
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation 
#### Issues
currently, the scroll icon is overlapping with the scroll bar.
also some text may hide behind the scroll icon.

![overlapping](https://user-images.githubusercontent.com/51117080/67615340-0992c900-f780-11e9-8045-fa1afda9f1f5.PNG)


Also, there is unnecessary top margin on
 the login page, which hides other options.




#### Changes proposed in this pull request:


![2](https://user-images.githubusercontent.com/51117080/67615381-67271580-f780-11e9-9a39-c84edc4469f8.PNG)


![22](https://user-images.githubusercontent.com/51117080/67615390-98074a80-f780-11e9-8b1a-110ac03513b8.PNG)


